### PR TITLE
updates rack version from 2.0.3 to 2.06

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
@@ -118,4 +118,4 @@ DEPENDENCIES
   webmock (~> 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
Following the security alert from GitHub (and ping from Andrei), I updated `rack` from `2.0.3` to `2.0.6`.

As per instructions in the `README.md`, I ran `docker-compose run --rm app ./bin/setup` to verify: all tests passed.

To verify that the vulnerability is gone, I ran `snyk test` locally to check and all looks good. Here are the _before_ and _after_:

BEFORE:

```
✗ Medium severity vulnerability found in rack
  Description: Cross-site Scripting (XSS)
  Info: https://snyk.io/vuln/SNYK-RUBY-RACK-72567
  Introduced through: rack-test@0.8.2, gcp_iap_warden@0.1.0
  From: rack-test@0.8.2 > rack@2.0.3
  From: gcp_iap_warden@0.1.0 > warden@1.2.7 > rack@2.0.3
  Remediation:
    Your dependencies are out of date, otherwise you would be using a newer version of rack.
    Try running `bundle update rack` and running `snyk test` again.

Tested 45 dependencies for known vulnerabilities, found 1 vulnerability, 2 vulnerable paths.
```

AFTER:

```
✓ Tested 45 dependencies for known vulnerabilities, no vulnerable paths found.
```