### PR TITLE
add initial support for app engine IAP

### DIFF
--- a/lib/gcp_iap_warden/strategy/google_jwt_header.rb
+++ b/lib/gcp_iap_warden/strategy/google_jwt_header.rb
@@ -15,17 +15,19 @@ module GcpIapWarden::Strategy
     class << self
       attr_accessor :jwt_options, :key_store
 
-      def config(project:, backend:)
-        raise "Invalid config for project" if project.nil?
-        raise "Invalid config for backend" if backend.nil?
+      def config(project_number:nil, backend:nil, project_id:nil)
+        raise "Invalid config for project number" if project_number.nil?
+        raise "Invalid config for backend" if backend.nil? && project_id.nil?
+        raise "Invalid config for project id" if project_id.nil? && backend.nil?
 
+        expected_aud = project_id.nil? ? "/projects/#{project_number}/global/backendServices/#{backend}" : "/projects/#{project_number}/apps/#{project_id}"
         @jwt_options = {
           algorithm: JWT_ALG,
           verify_iss: true,
           verify_iat: true,
           verify_aud: true,
           iss: JWT_ISS,
-          aud:  "/projects/#{project}/global/backendServices/#{backend}",
+          aud:  expected_aud,
         }
       end
 


### PR DESCRIPTION
Based on https://cloud.google.com/iap/docs/signed-headers-howto
```
aud 
Audience 
Must be a string with the following values:App 
  Engine: /projects/PROJECT_NUMBER/apps/PROJECT_IDCompute Engine and 
  GKE:    /projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID
```